### PR TITLE
Hotfix/remove oclif readme command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/fusion-cli",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equinor/fusion-cli",
   "description": "A cli for creating, starting, building, deploying and publishing Fusion apps and tiles",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": "Fusion Core",
   "bin": {
     "fusion": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equinor/fusion-cli",
   "description": "A cli for creating, starting, building, deploying and publishing Fusion apps and tiles",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "author": "Fusion Core",
   "bin": {
     "fusion": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -66,9 +66,8 @@
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "echo \"No test specified\"",
-    "version": "oclif-dev readme && git add README.md"
+    "prepack": "rimraf lib && tsc -b && oclif-dev manifest",
+    "test": "echo \"No test specified\""
   },
   "types": "lib/index.d.ts",
   "publishConfig": {


### PR DESCRIPTION
The oclif-dev readme command caused duplicates in the readme file.
It is removed from npm prepack and npm version 