### PR TITLE
Templates should now be copied in lib folder when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equinor/fusion-cli",
   "description": "A cli for creating, starting, building, deploying and publishing Fusion apps and tiles",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Fusion Core",
   "bin": {
     "fusion": "./bin/run"
@@ -64,9 +64,10 @@
   },
   "repository": "equinor/fusion-cli",
   "scripts": {
+    "copy": "cp -r src/templates/ lib/",
     "postpack": "rimraf oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && tsc -b && oclif-dev manifest",
+    "prepack": "rimraf lib && tsc -b && npm run copy && oclif-dev manifest",
     "test": "echo \"No test specified\""
   },
   "types": "lib/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src",
     "strict": true,
     "target": "es2017",
-    "composite": true,
+    "composite": false,
     "allowSyntheticDefaultImports": true
   },
   "include": [


### PR DESCRIPTION
The tarball created by npm publish does not include templates. 
Added a new copy command that ensures the templates folder beeing copied into the lib folder
Bumped up version 