### PR TITLE
Removed endOfLine from prettier config  in templates

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,5 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "semi": true,
-    "endOfLine": "crlf",
     "tabWidth": 4
 }

--- a/src/templates/app/.prettierrc
+++ b/src/templates/app/.prettierrc
@@ -3,6 +3,5 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "semi": true,
-    "endOfLine": "crlf",
     "tabWidth": 4
 }

--- a/src/templates/report/.prettierrc
+++ b/src/templates/report/.prettierrc
@@ -3,6 +3,5 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "semi": true,
-    "endOfLine": "crlf",
     "tabWidth": 4
 }


### PR DESCRIPTION
Removed endOfLine from prettier confiog  in templates setups and cli base prettier config
Since im asked to remove this in every new app I create. Might as well make it official. 